### PR TITLE
Implement beats per bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
             <div id="bpm">
                 <input type="number" value="60" onchange="bpmChange(this.value)" id="bpm-input">
                 <span>BPM</span>
+                <input type="number" value="4" min="1" onchange="bpbChange(this.value)" id="bpb-input">
+                <span title="Beats Per Bar">BPB</span>
                 <div id="start-btn">
                     <input type="button" data-action="Start" value="Start Metronome" onclick="handleClick(event)">
                 </div>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ let metronome = document.getElementById("metronome");
 let bpm = 60; // beats per minute
 let tick = 60 / bpm; // time of one beats
 
+let beatNum = 0;
+let bpb = 4;
+
 let timer; // timer for background color change
 let pBarTimer; // timer for progress bar
 
@@ -20,6 +23,12 @@ function getRandomColor() {
 function bpmChange(val) {
 	bpm = val;
 	tick = 60 / bpm;
+}
+
+function bpbChange(beats) {
+	// start a new bar when the beat changes
+	beatNum = 0;
+	bpb = beats;
 }
 
 function move() {
@@ -40,7 +49,13 @@ function move() {
 // cahnge color and play sound when progress bar is 100% width
 function endProgress() {
 	metronome.style.background = getRandomColor();
-	new Audio("assets/click.wav").play();
+	if (beatNum == 0) {
+		// Do something for the first beat
+		new Audio("assets/click.wav").play();
+	} else {
+		new Audio("assets/click.wav").play();
+	}
+	beatNum = (beatNum + 1) % bpb;
 }
 
 //when clicking button


### PR DESCRIPTION
There is now a second number input. It specifies the number of beats in a bar.

I am not sure what the intended behaviour is, but I assume it will mean something different happens on the first beat in every bar. This code in `script.js` can easily be changed to implement such behaviour:

```js
// cahnge color and play sound when progress bar is 100% width
function endProgress() {
	metronome.style.background = getRandomColor();
	if (beatNum == 0) {
		// Do something for the first beat
		new Audio("assets/click.wav").play();
	} else {
		new Audio("assets/click.wav").play();
	}
	beatNum = (beatNum + 1) % bpb;
}
```